### PR TITLE
Split the Java code into a library and an application

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,7 +26,7 @@ android {
             //packagingOptions {
             //    doNotStrip '**/*.so'
             //}
-            debuggable true
+            // debuggable true
         }
     }
     compileOptions {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ android {
     defaultConfig {
         applicationId "org.linebender.android.viewdemo"
         minSdk 28
-        targetSdk 31
+        targetSdk 33
         versionCode 1
         versionName "1.0"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,6 +2,8 @@ plugins {
     id 'com.android.application'
 }
 
+group = "org.linebender.android.rustview"
+
 android {
     ndkVersion "25.2.9519653"
     compileSdk 31

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,7 +26,7 @@ android {
             //packagingOptions {
             //    doNotStrip '**/*.so'
             //}
-            //debuggable true
+            debuggable true
         }
     }
     compileOptions {
@@ -39,4 +39,5 @@ android {
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.core:core:1.5.0'
+    implementation project(":library")
 }

--- a/app/src/main/java/org/linebender/android/viewdemo/DemoView.java
+++ b/app/src/main/java/org/linebender/android/viewdemo/DemoView.java
@@ -2,7 +2,7 @@ package org.linebender.android.viewdemo;
 
 import android.content.Context;
 
-import org.linebender.android.RustView;
+import org.linebender.android.rustview.RustView;
 
 public final class DemoView extends RustView {
     @Override

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '8.0.0' apply false
-    id 'com.android.library' version '8.0.0' apply false
+    id 'com.android.application' version '8.9.0' apply false
+    id 'com.android.library' version '8.9.0' apply false
 }
 
 task clean(type: Delete) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon May 02 15:39:12 BST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,6 +2,8 @@ plugins {
     id 'com.android.library'
 }
 
+group = "org.linebender.android.rustview"
+
 android {
     compileSdk 31
     defaultConfig {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,0 +1,18 @@
+plugins {
+    id 'com.android.library'
+}
+
+android {
+    compileSdk 31
+    defaultConfig {
+        minSdk 28
+        versionCode 1
+        versionName "1.0.0"
+    }
+    namespace 'org.linebender.android.rustview'
+}
+
+dependencies {
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.core:core:1.5.0'
+}

--- a/library/src/main/java/org/linebender/android/rustview/RustInputConnection.java
+++ b/library/src/main/java/org/linebender/android/rustview/RustInputConnection.java
@@ -1,4 +1,4 @@
-package org.linebender.android;
+package org.linebender.android.rustview;
 
 import android.os.Bundle;
 import android.os.Handler;

--- a/library/src/main/java/org/linebender/android/rustview/RustView.java
+++ b/library/src/main/java/org/linebender/android/rustview/RustView.java
@@ -9,7 +9,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE.chromium file.
 
-package org.linebender.android;
+package org.linebender.android.rustview;
 
 import android.content.Context;
 import android.graphics.Rect;

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,3 +14,4 @@ dependencyResolutionManagement {
 }
 
 include ':app'
+include ':library'

--- a/src/view.rs
+++ b/src/view.rs
@@ -715,7 +715,7 @@ pub fn register_view_class<'local, 'other_local>(
     static REGISTER_BASE_NATIVES: Once = Once::new();
     REGISTER_BASE_NATIVES.call_once(|| {
         env.register_native_methods(
-            "org/linebender/android/RustView",
+            "org/linebender/android/rustview/RustView",
             &[
                 NativeMethod {
                     name: "onMeasureNative".into(),


### PR DESCRIPTION
This is to enable an experiment of using this externally, i.e. in Vello's repository.

The actual changes are surprisingly trivial

It also needed to upgrade gradle etc. This is because I was getting a `NullPointerException` with the previous version of the Android Plugin, and upgrading fixed that